### PR TITLE
fix: release please comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          number: '${{ needs.Process.outputs.pr }}'
+          number: '${{ needs.Process.outputs.pr.number }}'
           id: production-deployment-url
           message: 'Production deployment started'
 
@@ -90,7 +90,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          number: '${{ needs.Process.outputs.pr }}'
+          number: '${{ needs.Process.outputs.pr.number }}'
           id: production-deployment-url
           message: |
             Production deployment successful
@@ -104,7 +104,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          number: '${{ needs.Process.outputs.pr }}'
+          number: '${{ needs.Process.outputs.pr.number }}'
           id: production-deployment-url
           message: Development Deployment Started
 
@@ -125,7 +125,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          number: '${{ needs.Process.outputs.pr }}'
+          number: '${{ needs.Process.outputs.pr.number }}'
           id: development-deployment-url
           message: |
             Development deployment successful


### PR DESCRIPTION
When attempting to find a reference number to the pull request that relates to the release created/updated, use the number in the object rather than assuming the object was just a number.